### PR TITLE
fix: clean up contact meta tags

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -6,8 +6,6 @@
   
   <!-- Page Title -->
   <title>Raphael B. Dias - Data Analytics & Strategic Consulting</title>
-  <meta name="description" content="Raphael B. Dias transforms complex data into clear insights, offering data analytics, machine learning, and strategic consulting services." />
-  
   <!-- Meta Description -->
   <meta name="description" content="Raphael B. Dias is a Decision Support Analyst specializing in Data Analytics &amp; Strategic Consulting. Explore projects, services, and career milestones." />
   
@@ -20,7 +18,7 @@
   <meta name="twitter:card" content="summary_large_image">
   
   <!-- Canonical URL -->
-  <link rel="canonical" href="https://raphaelbdias.com/">
+  <link rel="canonical" href="https://raphaelbdias.com/contact.html">
   
   <!-- Favicon -->
   <link rel="icon" href="favicon.ico" type="image/x-icon">


### PR DESCRIPTION
## Summary
- remove redundant meta description from contact page
- point canonical link to contact URL

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68962310f5d0832e80393ed2efd6f8bc