### PR TITLE
Add alt text to site images for accessibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -308,7 +308,7 @@
 <!-- Modal for Full View -->
 <div id="imageModal" class="modal">
   <span class="close">&times;</span>
-  <img class="modal-content" id="modalImage">
+  <img class="modal-content" id="modalImage" alt="Expanded gallery image">
 </div>
 
 
@@ -358,9 +358,10 @@
     
       items.forEach(item => {
         item.addEventListener('click', function() {
-          const imgSrc = item.querySelector('img').src;
+          const imgEl = item.querySelector('img');
           modal.style.display = 'block';
-          modalImg.src = imgSrc;
+          modalImg.src = imgEl.src;
+          modalImg.alt = imgEl.alt;
         });
       });
     

--- a/legacy/generic.html
+++ b/legacy/generic.html
@@ -57,7 +57,7 @@
               <!-- First case study -->
               
             <p style="text-align:center">An in-depth analysis of the AirBnb New York.</p>
-            <a href="/case_airbnb" class="image main"><img src="https://raphaeldias.me/images/airbnb01.jpg" alt="" /></a>
+            <a href="/case_airbnb" class="image main"><img src="https://raphaeldias.me/images/airbnb01.jpg" alt="Airbnb case study thumbnail" /></a>
             <br>
             <article>
                <ul class="actions special">
@@ -68,7 +68,7 @@
               <!-- Second case study -->
               
             <p style="text-align:center">An in-depth analysis of the sample Super Store in the USA.</p>
-            <a href="/superstore" class="image main"><img src="https://raphaeldias.me/images/superstore.jpg" alt="" /></a>
+            <a href="/superstore" class="image main"><img src="https://raphaeldias.me/images/superstore.jpg" alt="Superstore case study thumbnail" /></a>
             <br>
             <article>
                <ul class="actions special">
@@ -80,7 +80,7 @@
          <!-- Third case study -->
               
             <p style="text-align:center">Check out the stock market analysis using Yahoo Finance Live Data</p>
-            <a href="https://raphaeldias.streamlit.app/" class="image main"><img src="https://raphaeldias.me/images/stock_img.jpg" alt="" /></a>
+            <a href="https://raphaeldias.streamlit.app/" class="image main"><img src="https://raphaeldias.me/images/stock_img.jpg" alt="Stock market analysis thumbnail" /></a>
             <br>
             <article>
                <ul class="actions special">
@@ -91,7 +91,7 @@
          <!-- Fourth case study -->
               
             <p style="text-align:center">A fun recreation of the Riddlers Game for the Batman.</p>
-            <a href="/rataalada" class="image main"><img src="https://raphaeldias.me/images/pic05.jpg" alt="" /></a>
+            <a href="/rataalada" class="image main"><img src="https://raphaeldias.me/images/pic05.jpg" alt="Rataalada game thumbnail" /></a>
             <br>
             <article>
                <ul class="actions special">
@@ -102,7 +102,7 @@
           <!-- Fifth case study -->
               
             <p style="text-align:center">Article describing NLP with Twitter data.</p>
-            <a href="/twint" class="image main"><img src="https://raphaeldias.me/images/twit.jpg" alt="" /></a>
+            <a href="/twint" class="image main"><img src="https://raphaeldias.me/images/twit.jpg" alt="Twitter data analysis article thumbnail" /></a>
             <br>
             <article>
                <ul class="actions special">

--- a/legacy/professional.html
+++ b/legacy/professional.html
@@ -87,7 +87,7 @@
                   cambrian College, Canada.</a>
                </h2>
             </header>
-            <a href="https://cambriancollege.ca/about/planning-and-research/" class="image fit"><img src="https://raphaeldias.me/images/ir.jpg" alt="" width="350" height="340"/></a>
+            <a href="https://cambriancollege.ca/about/planning-and-research/" class="image fit"><img src="https://raphaeldias.me/images/ir.jpg" alt="Cambrian College research team" width="350" height="340"/></a>
             <p>Optimized algorithms, enhanced data accuracy, and guided students, achieving efficient report generation and advanced analysis for Power BI dashboards.</p>
             <ul class="actions special">
                <li><a href="https://cambriancollege.ca/about/planning-and-research/" class="button">GO TO COMPANY PAGE</a></li>
@@ -100,7 +100,7 @@
                   NorthStarDoc, USA.</a>
                </h2>
             </header>
-            <a href="https://medicalschedulinghub.com/" class="image fit"><img src="https://raphaeldias.me/images/pic02.jpg" alt="" width="350" height="340"/></a>
+            <a href="https://medicalschedulinghub.com/" class="image fit"><img src="https://raphaeldias.me/images/pic02.jpg" alt="NorthStarDoc software interface" width="350" height="340"/></a>
             <p>Spearheaded automation and data analysis initiatives at NorthStarDoc, resulting in the improved profile set-up and referral conversion rates.</p>
             <ul class="actions special">
                <li><a href="https://medicalschedulinghub.com/" class="button">GO TO COMPANY PAGE</a></li>
@@ -113,7 +113,7 @@
                   SixthFactor, UAE.</a>
                </h2>
             </header>
-            <a href="https://sixthfactor.com/" class="image fit"><img src="https://raphaeldias.me/images/pic03.jpg" alt="" width="350" height="350"/></a>
+            <a href="https://sixthfactor.com/" class="image fit"><img src="https://raphaeldias.me/images/pic03.jpg" alt="SixthFactor analytics team" width="350" height="350"/></a>
             <p>Expertise in web scraping, NLP and sentiment analysis, resulting in actionable insights and data-driven strategy for clients.</p>
             <ul class="actions special">
                <li><a href="https://sixthfactor.com/" class="button">GO TO COMPANY PAGE</a></li>
@@ -126,7 +126,7 @@
                   iDeas Unlimited, India</a>
                </h2>
             </header>
-            <a href="#" class="image fit"><img src="https://raphaeldias.me/images/pic04.jpg" alt="" width="350" height="340"/></a>
+            <a href="#" class="image fit"><img src="https://raphaeldias.me/images/pic04.jpg" alt="iDeas Unlimited data analysis" width="350" height="340"/></a>
             <p>Proven success in tracking and analyzing web and social media trends using Python and Tableau, resulting in the development of a powerful social listening tool for brands and their competitors.</p>
             <ul class="actions special">
                <li><a href="https://www.ideasunlimited.digital/" class="button">GO TO COMPANY PAGE</a></li>
@@ -139,7 +139,7 @@
                   Cambrian College, Canada</a>
                </h2>
             </header>
-            <a href="#" class="image fit"><img src="https://raphaeldias.me/images/pic05.jpg" alt="" width="350" height="330"/></a>
+            <a href="#" class="image fit"><img src="https://raphaeldias.me/images/pic05.jpg" alt="Academic project screenshot" width="350" height="330"/></a>
             <p>Rataalada is a game that utilises a combination of problem-solving and detective skills to navigate through various levels and challenges the Riddler presents while also incorporating elements of player popularity and health as a means of progress tracking. The game concludes with a tease of a potential sequel through the Riddler's final task.</p>
             <ul class="actions special">
                <li><a href="https://replit.com/@RaphaelDias4/rataalada?v=1" class="button">PLAY NOW</a></li>

--- a/legacy2/about.html
+++ b/legacy2/about.html
@@ -42,47 +42,47 @@
               <!-- First set of hobby cards -->
 
               <div class="hobby-card">
-                <img src="images main/other/camping.jpeg"  class="hobby-image">
+                <img src="images main/other/camping.jpeg" alt="Camping tent in the woods" class="hobby-image">
               </div>
 
               <div class="hobby-card">
-                <img src="images main/other/chess.jpeg" class="hobby-image">
+                <img src="images main/other/chess.jpeg" alt="Chessboard with pieces" class="hobby-image">
               </div>
 
               <div class="hobby-card">
-                <img src="images main/other/guitar.jpeg" class="hobby-image">
+                <img src="images main/other/guitar.jpeg" alt="Acoustic guitar" class="hobby-image">
               </div>
 
               <div class="hobby-card">
-                <img src="images main/other/camping2.jpeg"  class="hobby-image">
+                <img src="images main/other/camping2.jpeg" alt="Tent beside a lake" class="hobby-image">
               </div>
 
               <div class="hobby-card">
-                <img src="images main/other/camping3.jpeg"  class="hobby-image">
+                <img src="images main/other/camping3.jpeg" alt="Mountain campsite" class="hobby-image">
               </div>
 
               <div class="hobby-card">
-                <img src="images main/other/chess2.jpeg"  class="hobby-image">
+                <img src="images main/other/chess2.jpeg" alt="Close-up of chess pieces" class="hobby-image">
               </div>
               <!-- Duplicate the items for continuous scrolling -->
               <div class="hobby-card">
-                <img src="images main/other/camping.jpeg"  class="hobby-image">
+                <img src="images main/other/camping.jpeg" alt="Camping tent in the woods" class="hobby-image">
               </div>
 
               <div class="hobby-card">
-                <img src="images main/other/guitar.jpeg" class="hobby-image">
+                <img src="images main/other/guitar.jpeg" alt="Acoustic guitar" class="hobby-image">
               </div>
 
               <div class="hobby-card">
-                <img src="images main/other/camping2.jpeg"  class="hobby-image">
+                <img src="images main/other/camping2.jpeg" alt="Tent beside a lake" class="hobby-image">
               </div>
 
               <div class="hobby-card">
-                <img src="images main/other/camping3.jpeg"  class="hobby-image">
+                <img src="images main/other/camping3.jpeg" alt="Mountain campsite" class="hobby-image">
               </div>
 
               <div class="hobby-card">
-                <img src="images main/other/chess2.jpeg"  class="hobby-image">
+                <img src="images main/other/chess2.jpeg" alt="Close-up of chess pieces" class="hobby-image">
               </div>
 
           </div>


### PR DESCRIPTION
## Summary
- Provide descriptive alt text for hobby images in legacy about page
- Add alt text for modal image and sync alt text in viewer
- Ensure project and professional pages include meaningful alt attributes

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest` *(no tests ran)*

------
https://chatgpt.com/codex/tasks/task_e_6896231ac22c832e8be81cbd7e90ef4b