### PR TITLE
Remove duplicate base reset from styles.css

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -5,12 +5,6 @@
     box-sizing: border-box;
   }
   
-/* Base Reset */
-* {
-  margin: 0;
-  padding: 0;
-  box-sizing: border-box;
-}
 
 /* Body & Global Styles */
 body {


### PR DESCRIPTION
## Summary
- remove redundant universal reset block in styles.css

## Testing
- `npx stylelint styles.css` *(fails: 403 Forbidden when fetching stylelint)*
- `csslint styles.css` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68962322fb14832eb3532e4cfa94307a